### PR TITLE
Update na verificação de estado final

### DIFF
--- a/boku server.ipynb
+++ b/boku server.ipynb
@@ -248,6 +248,8 @@
     "                    else:\n",
     "                        prev_state = state\n",
     "                        c = 1\n",
+    "                else:\n",
+    "                    c=0\n",
     "                if c==5:\n",
     "                    return state\n",
     "\n",
@@ -267,6 +269,8 @@
     "                    else:\n",
     "                        prev_state = state\n",
     "                        c = 1\n",
+    "                else:\n",
+    "                    c=0\n",
     "                if c==5:\n",
     "                    return state\n",
     "                coords = self.neighbors(column,line)[1]              \n",
@@ -287,6 +291,8 @@
     "                    else:\n",
     "                        prev_state = state\n",
     "                        c = 1\n",
+    "                else:\n",
+    "                    c=0\n",
     "                if c==5:\n",
     "                    return state\n",
     "                coords = self.neighbors(column,line)[4]    \n",
@@ -491,7 +497,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
A verificação de estado final estava testando positivo para linhas/diagonais com 5 peças de um jogador que não estavam uma do lado da outra (não estavam as 5 em sequência). Por exemplo, tinha uma diagonal com a seguinte sequência: 1 peça vermelha, 2 espaços em branco, 3 peças vermelhas, 1 espaço em branco e 1 peça vermelha. São 5 peças vermelhas na mesma diagonal mas elas não estão "conectadas". Isso estava testando positivo. Agora, está zerando o contador quando a sequência é interrompida por espaços em branco.